### PR TITLE
feat: support jvm options and K8s resources quota

### DIFF
--- a/charts/shenyu/Chart.yaml
+++ b/charts/shenyu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: shenyu
 description: Helm Chart for deploying Apache ShenYu in Kubernetes
 type: application
-version: 0.3.1
+version: 0.4.0
 appVersion: "2.5.0"
 icon: https://shenyu.apache.org/img/logo.png
 maintainers:

--- a/charts/shenyu/README.md
+++ b/charts/shenyu/README.md
@@ -98,19 +98,45 @@ Select the corresponding Chart version according to the version of ShenYu you wa
 helm install shenyu shenyu/shenyu -n=shenyu --version=0.2.0 --create-namespace
 ```
 
+### How to configure JVM options and modify Kubernetes resource quotas(Version of ShenYu > 2.5.0)
+
+* Configure JVM parameters via `admin.jvmOpts` and `bootstrap.jvmOpts`
+* Configure Kubernetes resource quotas via `admin.resources` and `bootstrap.resources`.
+
+e.g.
+
+```shell
+helm install shenyu shenyu/shenyu -n=shenyu --create-namespace \
+      --set admin.javaOpts="-Xms256m -Xmx512m" \
+      --set admin.resources.requests.memory=512Mi \
+      --set admin.resources.limits.memory=1Gi \
+      --set admin.resources.requests.cpu=500m \
+      --set admin.resources.limits.cpu=1 \
+```
+
 ## Values configuration instructions
 
 ### Global Configuration
-| configuration-item | type   | default                     | description                                                                                        |
-|--------------------|--------|-----------------------------|----------------------------------------------------------------------------------------------------|
-| replicas           | int    | `1`                         | Number of replicas                                                                                 |
-| version            | string | `"2.5.0"`                   | shenyu version, it is not recommended to modify, please install the corresponding version directly |
-| admin.enabled      | bool   | `true`                      | Whether to install shenyu-admin                                                                    |
-| admin.image        | string | `"apache/shenyu-admin"`     | shenyu-admin image                                                                                 |
-| admin.nodePort     | int    | `31095`                     | shenyu-admin NodePort                                                                              |
-| bootstrap.enabled  | bool   | `true`                      | whether to install shenyu-bootstrap                                                                |
-| bootstrap.image    | string | `"apache/shenyu-bootstrap"` | shenyu-bootstrap image                                                                             |
-| bootstrap.nodePort | int    | `31195`                     | shenyu-bootstrap NodePort                                                                          |
+| configuration item | type   | default   | description                                                                                        |
+|--------------------|--------|-----------|----------------------------------------------------------------------------------------------------|
+| replicas           | int    | `1`       | Number of replicas                                                                                 |
+| version            | string | `"2.5.0"` | shenyu version, it is not recommended to modify, please install the corresponding version directly |
+
+### shenyu-admin configuration
+| configuration item | type   | default                                                                                                     | description        |
+|--------------------|--------|-------------------------------------------------------------------------------------------------------------|--------------------|
+| admin.nodePort     | int    | `31095`                                                                                                     | NodePort port      |
+| admin.javaOpts     | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM parameters     |
+| admin.resources    | dict   | omit                                                                                                        | K8s resource quota |
+
+### shenyu-bootstrap configuration
+| configuration item  | type   | default                                                                                                         | description        |
+|---------------------|--------|-----------------------------------------------------------------------------------------------------------------|--------------------|
+| bootstrap.nodePort  | int    | `31195`                                                                                                         | NodePort Port      |
+| bootstrap.javaOpts  | string | [see here](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM parameters     |
+| bootstrap.resources | dict   | `{}`                                                                                                            | K8s resource quota |
+
+Translated with www.DeepL.com/Translator (free version)                                                                     |
 
 ### Database configuration
 
@@ -137,14 +163,14 @@ helm install shenyu shenyu/shenyu -n=shenyu --version=0.2.0 --create-namespace
 | dataSource.mysql.connectorVersion | string | `"8.0.23"`                   | connector version([maven connector list](https://repo1.maven.org/maven2/mysql/mysql-connector-java/)) |
 
 ### PostgreSQL
-| configuration-item             | type   | default           | description                                                                                           |
-|--------------------------------|--------|-------------------|-------------------------------------------------------------------------------------------------------|
-| dataSource.pg.ip               | string | `""`              | IP                                                                                                    |
-| dataSource.pg.port             | int    | `5432`            | port                                                                                                  |
-| dataSource.pg.username         | string | `"postgres"`      | username                                                                                              |
-| dataSource.pg.password         | string | `"postgres"`      | password                                                                                              |
-| dataSource.pg.driverClass      | string | `"org.pg.Driver"` | PostgreSQL driver class name                                                                          |
-| dataSource.pg.connectorVersion | string | `"42.2.18"`       | connector version ([maven connector list](https://repo1.maven.org/maven2/org/postgresql/postgresql/)) |
+| configuration-item             | type   | default                   | description                                                                                           |
+|--------------------------------|--------|---------------------------|-------------------------------------------------------------------------------------------------------|
+| dataSource.pg.ip               | string | `""`                      | IP                                                                                                    |
+| dataSource.pg.port             | int    | `5432`                    | port                                                                                                  |
+| dataSource.pg.username         | string | `"postgres"`              | username                                                                                              |
+| dataSource.pg.password         | string | `"postgres"`              | password                                                                                              |
+| dataSource.pg.driverClass      | string | `"org.postgresql.Driver"` | PostgreSQL driver class name                                                                          |
+| dataSource.pg.connectorVersion | string | `"42.2.18"`               | connector version ([maven connector list](https://repo1.maven.org/maven2/org/postgresql/postgresql/)) |
 
 ### application.yml configuration
 | configuration-item          | type   | default  | description                                                                                                                                          |
@@ -251,27 +277,51 @@ shenyu/shenyu   0.2.0           2.5.0         Helm Chart for deploying Apache Sh
 helm install shenyu shenyu/shenyu -n=shenyu --version=0.2.0 --create-namespace
 ```
 
+### 如何配置 JVM 参数以及修改 Kubernetes 资源配额(ShenYu 版本 > 2.5.0)
+
+* 通过 `admin.javaOpts` 和 `bootstrap.javaOpts` 来配置 JVM 参数
+* 通过 `admin.resources` 和 `bootstrap.resources` 来配置 Kubernetes 资源配额。
+
+例：
+
+```shell
+helm install shenyu shenyu/shenyu -n=shenyu --create-namespace \
+      --set admin.javaOpts="-Xms256m -Xmx512m" \
+      --set admin.resources.requests.memory=512Mi \
+      --set admin.resources.limits.memory=1Gi \
+      --set admin.resources.requests.cpu=500m \
+      --set admin.resources.limits.cpu=1 \
+```
+
 ## Values 配置说明
 
 ### 全局配置
-| 配置项              | 类型    | 默认值                       | 描述                                   |
-|--------------------|--------|-----------------------------|---------------------------------------|
-| replicas           | int    | `1`                         | 副本数量                               |
-| version            | string | `"2.5.0"`                   | shenyu 版本，不建议修改，请直接安装对应版本 |
-| admin.enabled      | bool   | `true`                      | 是否安装 shenyu-admin                  |
-| admin.image        | string | `"apache/shenyu-admin"`     | shenyu-admin 镜像                      |
-| admin.nodePort     | int    | `31095`                     | shenyu-admin NodePort 端口             |
-| bootstrap.enabled  | bool   | `true`                      | 是否安装 shenyu-bootstrap              |
-| bootstrap.image    | string | `"apache/shenyu-bootstrap"` | shenyu-bootstrap 镜像                  |
-| bootstrap.nodePort | int    | `31195`                     | shenyu-bootstrap NodePort 端口         |
+| 配置项    | 类型    | 默认值     | 描述                                   |
+|----------|--------|-----------|---------------------------------------|
+| replicas | int    | `1`       | 副本数量                               |
+| version  | string | `"2.5.0"` | shenyu 版本，不建议修改，请直接安装对应版本 |
+
+### shenyu-admin 配置
+| 配置项           | 类型    | 默认值                                                                                                      | 描述          |
+|-----------------|--------|------------------------------------------------------------------------------------------------------------|--------------|
+| admin.nodePort  | int    | `31095`                                                                                                    | NodePort 端口 |
+| admin.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-admin-dist/docker/entrypoint.sh) | JVM 参数      |
+| admin.resources | dict   | 略                                                                                                         | K8s 资源配额  |
+
+### shenyu-bootstrap 配置
+| 配置项               | 类型    | 默认值                                                                                                          | 描述          |
+|---------------------|--------|----------------------------------------------------------------------------------------------------------------|--------------|
+| bootstrap.nodePort  | int    | `31195`                                                                                                        | NodePort 端口 |
+| bootstrap.javaOpts  | string | [详见这里](https://github.com/apache/shenyu/blob/master/shenyu-dist/shenyu-bootstrap-dist/docker/entrypoint.sh) | JVM 参数      |
+| bootstrap.resources | dict   | `{}`                                                                                                           | K8s 资源配额  |
 
 ### 数据库配置
 
 #### 数据库总配置
-| 配置项                  | 类型    | 默认值  | 描述                           |
-|------------------------|--------|--------|-------------------------------|
-| dataSource.active      | string | `"h2"` | 使用的数据库，支持 `h2`, `mysql` |
-| dataSource.initEnabled | bool   | `true` | 初始化数据库，仅 `h2` 有效       |
+| 配置项                  | 类型    | 默认值  | 描述                                 |
+|------------------------|--------|--------|-------------------------------------|
+| dataSource.active      | string | `"h2"` | 使用的数据库，支持 `h2`, `mysql`, `pg` |
+| dataSource.initEnabled | bool   | `true` | 初始化数据库，仅 `h2` 有效             |
 
 #### h2
 | 配置项                  | 类型    | 默认值  | 描述   |
@@ -296,7 +346,7 @@ helm install shenyu shenyu/shenyu -n=shenyu --version=0.2.0 --create-namespace
 | dataSource.pg.port             | int    | `5432`                    | 端口                                                                                              |
 | dataSource.pg.username         | string | `"postgres"`              | 用户名                                                                                            |
 | dataSource.pg.password         | string | `""`                      | 密码                                                                                              |
-| dataSource.pg.driverClass      | string | `"org.postgresql.Driver"` | postgresql driver class 名字                                                                      |
+| dataSource.pg.driverClass      | string | `"org.postgresql.Driver"` | PostgreSQL driver class 名字                                                                      |
 | dataSource.pg.connectorVersion | string | `"42.2.18"`               | connector 版本([maven connector 列表](https://repo1.maven.org/maven2/org/postgresql/postgresql/)) |
 
 ### application.yml 配置

--- a/charts/shenyu/templates/shenyu-admin-deployment.yaml
+++ b/charts/shenyu/templates/shenyu-admin-deployment.yaml
@@ -88,6 +88,10 @@ spec:
           env:
             - name: 'TZ'
               value: 'Asia/Beijing'
+            - name: ADMIN_JVM
+              value: {{ .Values.admin.javaOpts | quote }}
+          resources:
+            {{- toYaml .Values.admin.resources | nindent 12 }}
           volumeMounts:
           - name: shenyu-admin-config
             mountPath: /opt/shenyu-admin/conf/application.yml

--- a/charts/shenyu/templates/shenyu-bootstrap-deployment.yaml
+++ b/charts/shenyu/templates/shenyu-bootstrap-deployment.yaml
@@ -39,6 +39,10 @@ spec:
           env:
             - name: TZ
               value: Asia/Beijing
+            - name: BOOT_JVM
+              value: {{ .Values.bootstrap.javaOpts | quote }}
+          resources:
+            {{- toYaml .Values.bootstrap.resources | nindent 12 }}
           volumeMounts:
             - name: shenyu-bootstrap-config
               mountPath: /opt/shenyu-bootstrap/conf/application.yml

--- a/charts/shenyu/values.yaml
+++ b/charts/shenyu/values.yaml
@@ -9,11 +9,31 @@ admin:
   image: apache/shenyu-admin
   # if you want to change "admin service port", please edit here
   nodePort: 31095
+  # jvm options for admin
+  javaOpts: ""
+  # K8s resources quota for admin
+  resources:
+#    requests:
+#      cpu: 100m
+#      memory: 512Mi
+#    limits:
+#      cpu: 1000m
+#      memory: 1024Mi
 bootstrap:
   enabled: true
   image: apache/shenyu-bootstrap
   # if you want to change "bootstrap service port", please edit here
   nodePort: 31195
+  # jvm options for bootstrap
+  javaOpts: ""
+  # K8s resources quota for bootstrap
+  resources:
+#    requests:
+#      cpu: 100m
+#      memory: 512Mi
+#    limits:
+#      cpu: 1000m
+#      memory: 1024Mi
 
 #################################################
 #     datasource config of shenyu-admin         #
@@ -45,7 +65,6 @@ dataSource:
     # pg driver class name
     driverClass: org.postgresql.Driver
     connectorVersion: 42.5.0
-  # not supported yet, coming soon
   oracle:
     ip:
     port: 1521


### PR DESCRIPTION
## Feat

1. support JVM options
2. K8s resources quota

## Behaviors

Test with the latest **dev** image version

```shell
helm repo add bird-shenyu https://aflybird0.github.io/shenyu-helm-chart
helm repo update

helm install shenyu1004 bird-shenyu/shenyu -n=shenyu --create-namespace \
  --set admin.javaOpts="-XX:MaxRAMPercentage=80.0" \
  --set admin.resources.requests.memory=1024Mi \
  --set admin.resources.limits.memory=2Gi \
  --set version=latest \
  --set admin.image=aflybird0/shenyu-admin \
  --set bootstrap.image=aflybird0/shenyu-bootstrap
```

<img width="968" alt="image" src="https://user-images.githubusercontent.com/36830265/193450254-f89896a5-4324-4000-ade3-60918290747e.png">


<img width="958" alt="image" src="https://user-images.githubusercontent.com/36830265/193450300-c2eeb17f-b897-49ed-9d05-02b703d966dd.png">


<img width="793" alt="image" src="https://user-images.githubusercontent.com/36830265/193450424-ea51c3bd-ce84-4d2b-ac77-51e67c9be83f.png">


## Docker image info

(executed by [make build-all-image](https://github.com/apache/shenyu/blob/master/Makefile), based on 115e33accc, yunlongn [yunlongn@outlook.com](mailto:yunlongn@outlook.com), Thu Sep 29 17:09:49 2022 +0800)
